### PR TITLE
Compile on Solaris 11 (Solaris zone on SmartOS, with gcc 4.7 installed)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -42,3 +42,10 @@ endif
 ifeq ($(OS), WINNT)
 SHLIB_EXT = dll
 endif
+
+# SunOS with gcc
+ifeq ($(OS), SunOS)
+SHLIB_EXT = so
+CFLAGS-add+=-fPIC
+FFLAGS-add+=-fPIC
+endif


### PR DESCRIPTION
Trying to get Julia compiled on Solaris 11. Already fixed openspecfun, this came next.